### PR TITLE
Enhances i18n with AI translation badges

### DIFF
--- a/public/assets/i18n/de.json
+++ b/public/assets/i18n/de.json
@@ -19,15 +19,15 @@
     "description": "Antworten auf häufig gestellte Fragen zum i18n-Excel-Manager",
     "items": {
       "aiTranslation": {
-        "a": "Das Tool integriert sich mit Googles Gemini AI, um fehlende Werte automatisch zu übersetzen, wobei Platzhalter wie {{name}}, HTML-Tags und Ihre ursprüngliche Formatierung erhalten bleiben. Sie können wählen, welches Gemini-Modell für Übersetzungen verwendet werden soll.",
+        "a": "Das Tool integriert sich mit Googles Gemini AI, um fehlende Werte automatisch zu übersetzen, wobei Platzhalter wie {{name}}, HTML-Tags und deine ursprüngliche Formatierung erhalten bleiben. Du kannst wählen, welches Gemini-Modell für Übersetzungen verwendet werden soll.",
         "q": "Wie funktioniert die KI-Auto-Übersetzung?"
       },
       "angularIntegration": {
-        "a": "Sie können es über die interaktive CLI in Ihrem Projektverzeichnis verwenden oder programmgesteuert in Ihren Build-Prozess integrieren. Das Tool funktioniert mit der Standard-i18n-Struktur (z. B. public/assets/i18n oder src/assets/i18n).",
+        "a": "Du kannst es über die interaktive CLI in deinem Projektverzeichnis nutzen oder programmgesteuert in deinen Build-Prozess integrieren. Das Tool funktioniert mit der Standard-i18n-Struktur (z. B. public/assets/i18n oder src/assets/i18n).",
         "q": "Wie integriere ich dieses Tool in mein Angular-Projekt?"
       },
       "dryRun": {
-        "a": "Ja. Der Dry-Run-Modus ermöglicht es Ihnen, alle Änderungen vorab anzuzeigen, ohne Dateien zu ändern. Er beinhaltet eine Pfadvalidierung, um versehentliches Überschreiben zu verhindern, und zeigt Ihnen genau, was erstellt oder geändert würde.",
+        "a": "Ja. Der Dry-Run-Modus ermöglicht es dir, alle Änderungen vorab anzuzeigen, ohne Dateien zu ändern. Er beinhaltet eine Pfadvalidierung, um versehentliches Überschreiben zu verhindern, und zeigt dir genau, was erstellt oder geändert würde.",
         "q": "Gibt es eine sichere Möglichkeit, Änderungen vor der Anwendung anzuzeigen?"
       },
       "formatsSupported": {
@@ -35,7 +35,7 @@
         "q": "Welche Dateiformate werden unterstützt?"
       },
       "geminiApiKey": {
-        "a": "Ja, Sie benötigen einen Gemini-API-Schlüssel, um die KI-Auto-Übersetzungsfunktion zu nutzen. Einen kostenlosen API-Schlüssel erhalten Sie bei Google AI Studio unter https://makersuite.google.com/app/api-key.",
+        "a": "Ja, du benötigst einen Gemini-API-Schlüssel, um die KI-Auto-Übersetzung zu nutzen. Einen kostenlosen API-Schlüssel erhältst du bei Google AI Studio unter https://makersuite.google.com/app/api-key.",
         "q": "Benötige ich einen Gemini-API-Schlüssel für die KI-Auto-Übersetzung?"
       },
       "nestedKeys": {
@@ -74,7 +74,7 @@
         "title": "Bidirektionale Konvertierung"
       },
       "languageMapping": {
-        "description": "Verwenden Sie vollständige Sprachnamen in Excel-Headern (z. B. 'Deutsch' anstelle von 'de').",
+        "description": "Verwende vollständige Sprachnamen in Excel-Headern (z. B. 'Deutsch' anstelle von 'de').",
         "title": "Sprachzuordnung"
       },
       "nestedSupport": {
@@ -87,7 +87,7 @@
         "title": "Validierung"
       }
     },
-    "description": "Alles, was Sie zur Verwaltung der Internationalisierung in Ihren Projekten benötigen",
+    "description": "Alles, was du zur Verwaltung der Internationalisierung in deinen Projekten benötigst",
     "developerExperience": {
       "dryRunMode": {
         "description": "Änderungen vorab anzeigen, ohne Dateien zu schreiben. Sichere Pfadvalidierung enthalten.",
@@ -105,14 +105,14 @@
     "quickLinks": "Schnellzugriffe"
   },
   "gettingStarted": {
-    "description": "Installieren Sie über npm und führen Sie einen einzigen Befehl aus, um Ihre i18n-JSON-Dateien in Excel zu konvertieren oder umgekehrt.",
+    "description": "Installiere das Tool über npm und führe einen einzigen Befehl aus, um deine i18n-JSON-Dateien in Excel zu konvertieren oder umgekehrt.",
     "title": "In Sekundenschnelle starten"
   },
   "hero": {
     "newBadge": "neu",
     "newFeature": "Neueste Integration gerade eingetroffen",
     "subTitle": "Mühelose Konvertierung zwischen i18n-JSON-Dateien und Excel für Angular und moderne Webprojekte.",
-    "title": "Modernisieren Sie Ihre i18n-Übersetzungen mit KI"
+    "title": "Modernisiere deine i18n-Übersetzungen mit KI"
   },
   "languageNames": {
     "de": "Deutsch",
@@ -126,11 +126,11 @@
     "aiSection": {
       "aiBadge": "KI-gestützt",
       "aiTranslating": "KI übersetzt...",
-      "description": "Nie wieder manuell übersetzen. Die Gemini-Integration füllt fehlende Übersetzungen automatisch aus, während Ihre Platzhalter und Formatierungen erhalten bleiben.",
+      "description": "Nie wieder manuell übersetzen. Die Gemini-Integration füllt fehlende Übersetzungen automatisch aus, während deine Platzhalter und Formatierungen erhalten bleiben.",
       "perks": {
         "automaticTranslations": "Fehlende Werte mit Gemini AI automatisch übersetzen",
         "batchProcessing": "Stapelverarbeitung für Effizienz",
-        "chooseModel": "Wählen Sie aus mehreren Gemini-Modellen",
+        "chooseModel": "Wähle aus mehreren Gemini-Modellen",
         "preservePlaceholders": "Behält {{placeholders}}, HTML-Tags und Formatierung"
       },
       "title": "Automatische Übersetzung mit Gemini AI"

--- a/public/assets/i18n/de.json
+++ b/public/assets/i18n/de.json
@@ -1,5 +1,6 @@
 {
   "a11y": {
+    "aiTranslatedTooltip": "Mit KI übersetzt",
     "codeRegionLabel": "Code-Beispiel in {{lang}}",
     "copyCommand": "Installationsbefehl in die Zwischenablage kopieren",
     "languageSwitcherLabel": "Sprache auswählen",
@@ -141,6 +142,7 @@
     }
   },
   "tostify": {
+    "aiTranslatedHint": "Diese Sprache wurde mit KI übersetzt",
     "copySuccess": "In die Zwischenablage kopiert!"
   }
 }

--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "a11y": {
+    "aiTranslatedTooltip": "Translated using AI",
     "codeRegionLabel": "Code example in {{lang}}",
     "copyCommand": "Copy installation command to clipboard",
     "languageSwitcherLabel": "Select a language",
@@ -141,6 +142,7 @@
     }
   },
   "tostify": {
+    "aiTranslatedHint": "This language was translated using AI",
     "copySuccess": "Copied to clipboard!"
   }
 }

--- a/public/assets/i18n/es.json
+++ b/public/assets/i18n/es.json
@@ -141,6 +141,7 @@
     }
   },
   "tostify": {
+    "aiTranslatedHint": "Este idioma fue traducido por IA",
     "copySuccess": "¡Copiado al portapapeles!"
   }
 }

--- a/public/assets/i18n/fr.json
+++ b/public/assets/i18n/fr.json
@@ -141,6 +141,7 @@
     }
   },
   "tostify": {
+    "aiTranslatedHint": "Cette langue a été traduite par IA",
     "copySuccess": "Copié dans le presse-papiers !"
   }
 }

--- a/public/assets/i18n/pt.json
+++ b/public/assets/i18n/pt.json
@@ -141,6 +141,7 @@
     }
   },
   "tostify": {
+    "aiTranslatedHint": "Este idioma foi traduzido por IA",
     "copySuccess": "Copiado para a área de transferência!"
   }
 }

--- a/public/assets/i18n/tr.json
+++ b/public/assets/i18n/tr.json
@@ -141,6 +141,7 @@
     }
   },
   "tostify": {
+    "aiTranslatedHint": "Bu dil yapay zeka ile çevrildi",
     "copySuccess": "Panoya kopyalandı!"
   }
 }

--- a/src/app/core/components/language-switch/language-switch.css
+++ b/src/app/core/components/language-switch/language-switch.css
@@ -1,0 +1,12 @@
+.ai-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.125rem 0.25rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  border-radius: 9999px;
+  background-color: var(--color-i18n-lighter-blue);
+  color: var(--color-i18n-blue);
+  cursor: help;
+}

--- a/src/app/core/components/language-switch/language-switch.html
+++ b/src/app/core/components/language-switch/language-switch.html
@@ -25,8 +25,19 @@
         class="hover:bg-brand-secondary/80 flex cursor-pointer items-center justify-center transition-colors active:scale-95"
         role="none"
       >
-        <button #langButton (click)="onSelectLang(lang)" class="h-full w-full px-2 py-1 focus:outline-none" role="menuitem" type="button">
-          {{ 'languageNames.' + lang | translate }}
+        <button
+          #langButton
+          (click)="onSelectLang(lang)"
+          class="flex h-full w-full items-center justify-center gap-2 px-3 py-1 focus:outline-none"
+          role="menuitem"
+          type="button"
+        >
+          <span>{{ 'languageNames.' + lang | translate }}</span>
+          @if (isAiTranslated(lang)) {
+            <span [title]="'a11y.aiTranslatedTooltip' | translate" aria-label="AI translated" class="ai-badge">
+              <fa-icon [icon]="aiIcon" size="xs" />
+            </span>
+          }
         </button>
       </li>
     }

--- a/src/app/features/hero/hero.html
+++ b/src/app/features/hero/hero.html
@@ -10,7 +10,7 @@
       }}</span>
       {{ 'hero.newFeature' | translate }}
     </p>
-    <h1 class="text-4xl font-bold sm:text-5xl xl:text-7xl">{{ 'hero.title' | translate }}</h1>
+    <h1 class="text-4xl font-bold sm:text-5xl xl:text-6xl">{{ 'hero.title' | translate }}</h1>
     <p>{{ 'hero.subTitle' | translate }}</p>
   </header>
   <img

--- a/src/app/pages/home/home.spec.ts
+++ b/src/app/pages/home/home.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Home } from './home';
+import Home from './home';
 
 describe('Home', () => {
   let component: Home;

--- a/src/app/shared/components/feature-card/feature-card.html
+++ b/src/app/shared/components/feature-card/feature-card.html
@@ -1,5 +1,5 @@
 <article
-  class="border-border-subtle bg-bg-surface hover:border-border-highlight hover:bg-bg-surface-active focus-within:border-i18n-blue backdrop-blur-glass flex flex-col gap-4 rounded-lg border p-6 transition-all duration-300 focus-within:shadow-lg hover:-translate-y-1 hover:shadow-lg"
+  class="border-border-subtle bg-bg-surface hover:border-border-highlight hover:bg-bg-surface-active focus-within:border-i18n-blue backdrop-blur-glass flex min-h-[250px] flex-col gap-4 rounded-lg border p-6 transition-all duration-300 focus-within:shadow-lg hover:-translate-y-1 hover:shadow-lg"
 >
   <figure class="flex justify-center">
     <fa-icon [icon]="feature().icon" class="text-text-primary text-4xl" />

--- a/src/app/shared/services/environment.spec.ts
+++ b/src/app/shared/services/environment.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Environment } from './environment';
+import { EnvironmentService } from './environment';
 
 describe('Environment', () => {
-  let service: Environment;
+  let service: EnvironmentService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(Environment);
+    service = TestBed.inject(EnvironmentService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
Adds visual indicators to denote AI-translated languages.

This change introduces:
- AI badges in the language switcher to indicate AI-translated languages.
- Tooltips providing context about the AI translation.
- Adjustments to German translations for improved consistency.
- Minor styling improvements to feature cards and hero heading for better responsiveness.